### PR TITLE
Added query string to "post_logout_redirect_uri" for cache busting

### DIFF
--- a/apps/part2/src/main/resources/static/index.js
+++ b/apps/part2/src/main/resources/static/index.js
@@ -137,7 +137,7 @@
     }
 
     //------------------- 第6章で使用するサインアウト -------------------
-    const signOutLink = "/.auth/logout?post_logout_redirect_uri=/";
+    const signOutLink = "/.auth/logout?post_logout_redirect_uri=" + encodeURI("/?a=") + new Date().getTime(); 
     let isSignedIn = false;
     let userId = "?";
 


### PR DESCRIPTION
post_logout_redirect_uri=/ のようにアプリケーションルートを指定すると、サインアウト後にブラウザキャッシュによってサインインしていない状態でToDoリストの画面が表示される。
これを回避するため、クエリ文字列(a=new Date().getTime())を追加した。(cache busting)