### PR TITLE
fix: we must update dl.yarnpkg.com gpg key before apt-get update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,6 +21,8 @@ ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # (d4)
+RUN wget -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo deb https://dl.yarnpkg.com/debian/ stable main | sudo tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends wget apt-transport-https gnupg lsb-release \
     && wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add - \

--- a/.github/workflows/part1_ci.yml
+++ b/.github/workflows/part1_ci.yml
@@ -5,7 +5,7 @@ on:
     tags-ignore:
       - "*"
     branches:
-      - "main"
+      - "mrmt"
     paths:
       - 'apps/part1/**'
       - '.github/workflows/part1_ci.yml'

--- a/apps/part1/src/main/java/hello/Application.java
+++ b/apps/part1/src/main/java/hello/Application.java
@@ -14,6 +14,11 @@ public class Application {
 		return "Hello Docker World";
 	}
 
+	@RequestMapping("/about")
+	public String about() {
+		return "Hello Version 1.0";
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}


### PR DESCRIPTION
こんにちは。素敵な書籍をありがとうございます。

Section 2.2.2 のハンズオンコンテンツ
https://github.com/gihyo-book/azure-container-dev-book
で、指定の手順では以下のエラーが出て、サンプルコードをcontainerで開くことができませんでした。

```
 => CACHED [dev_container_auto_added_stage_label 2/4] RUN if [ "true" = "  0.0s 
 => CACHED [dev_container_auto_added_stage_label 3/4] RUN if [ "lts/*" !=  0.0s
 => ERROR [dev_container_auto_added_stage_label 4/4] RUN apt-get update &  2.5s 
------
 > [dev_container_auto_added_stage_label 4/4] RUN apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get -y install --no-install-recommends wget apt-transport-https gnupg lsb-release     && wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -     && echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list     && sudo apt-get update     && sudo apt-get install trivy:
#0 0.388 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
#0 0.396 Get:2 http://security.debian.org/debian-security bullseye-security InRelease [48.4 kB]
#0 0.468 Get:3 https://dl.yarnpkg.com/debian stable InRelease [17.1 kB]
#0 0.494 Get:4 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
#0 0.583 Get:5 http://security.debian.org/debian-security bullseye-security/main arm64 Packages [218 kB]

#0 0.682 Err:3 https://dl.yarnpkg.com/debian stable InRelease
#0 0.682   The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>

#0 0.692 Get:6 http://deb.debian.org/debian bullseye/non-free arm64 Packages [73.0 kB]
#0 0.776 Get:7 http://deb.debian.org/debian bullseye/contrib arm64 Packages [41.0 kB]
#0 0.780 Get:8 http://deb.debian.org/debian bullseye/main arm64 Packages [8,072 kB]
#0 1.534 Get:9 http://deb.debian.org/debian bullseye-updates/main arm64 Packages [12.0 kB]
#0 2.215 Reading package lists...
#0 2.516 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
#0 2.516 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
------
ERROR: failed to solve: executor failed running [/bin/sh -c apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get -y install --no-install-recommends wget apt-transport-https gnupg lsb-release     && wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -     && echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list     && sudo apt-get update     && sudo apt-get install trivy]: exit code: 100
[12247 ms] Error: Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /var/folders/8f/4cjxlbv175j36g041y96mzwm0000gn/T/devcontainercli/container-features/0.29.0-1676105509688/Dockerfile-with-features -t vsc-azure-container-dev-book-c49bc09416b1e9212e4c9c633412e436 --target dev_containers_target_stage --build-arg VARIANT=17-bullseye --build-arg INSTALL_MAVEN=true --build-arg INSTALL_GRADLE=false --build-arg NODE_VERSION=lts/* --build-context dev_containers_feature_content_source=/var/folders/8f/4cjxlbv175j36g041y96mzwm0000gn/T/devcontainercli/container-features/0.29.0-1676105509688 --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label --build-arg _DEV_CONTAINERS_IMAGE_USER=root --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp /Users/morimoto/git/azure-container-dev-book/.devcontainer
[12247 ms]     at pie (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:1916:1698)
[12247 ms]     at process.processTicksAndRejections (node:internal/process/task_queues:96:5)
[12247 ms]     at async vF (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:1915:1972)
[12247 ms]     at async P7 (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:1915:901)
[12247 ms]     at async Fie (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:1921:2093)
[12247 ms]     at async Vf (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:1921:3241)
[12247 ms]     at async eoe (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:2045:17324)
[12247 ms]     at async Qse (/Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js:2045:17065)
[12249 ms] Exit code 1
[12252 ms] Command failed: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin) --ms-enable-electron-run-as-node /Users/morimoto/.vscode/extensions/ms-vscode-remote.remote-containers-0.275.1/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /Users/morimoto/Library/Application Support/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-23727691-9e5b-4b37-8821-67f6ce7288db1676105507781 --workspace-folder /Users/morimoto/git/azure-container-dev-book --workspace-mount-consistency cached --id-label devcontainer.local_folder=/Users/morimoto/git/azure-container-dev-book --id-label devcontainer.config_file=/Users/morimoto/git/azure-container-dev-book/.devcontainer/devcontainer.json --log-level debug --log-format json --config /Users/morimoto/git/azure-container-dev-book/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[12252 ms] Exit code 1
```

以下のところは既知のエラーのようで、

```
#0 2.516 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
#0 2.516 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

aptで取ってくるdebの提供元のgpg鍵が古いようです。
pull requestにある追加を行うとcontailerがbuildできるようになりました。
vanillaではない、鍵をすでに更新済の環境だと、この追加なしでもapt-getできるのだと思います。

なお, `apt-get update` する前に `wget -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -` するだけではだめで, `echo deb https://dl.yarnpkg.com/debian/ stable main | sudo tee /etc/apt/sources.list.d/yarn.list` も必要でした。

ad-hocな修正ですが、ご参考になれば。